### PR TITLE
Feature: Updating GHA to use `trunk-action`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,7 @@ name: Deploy to Netlify on commits to main
 on:
   push:
     branches: [main]
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -12,9 +13,9 @@ jobs:
           toolchain: stable
           target: wasm32-unknown-unknown
       - name: Install trunk
-        uses: baptiste0928/cargo-install@v1
+        uses: jetli/trunk-action@v0.5.0
         with:
-          crate: trunk
+          version: "latest"
       - name: Install wasm-bindgen-cli
         uses: baptiste0928/cargo-install@v1
         with:


### PR DESCRIPTION
This PR updates the Github Action to use `trunk-action` instead of installing trunk from cargo.

Claims to run in seconds instead of minutes:
https://github.com/jetli/trunk-action